### PR TITLE
Added an open func to close the menu programatically

### DIFF
--- a/ContextMenuSwift/ContextMenu.swift
+++ b/ContextMenuSwift/ContextMenu.swift
@@ -253,6 +253,10 @@ open class ContextMenu: NSObject {
         }
     }
     
+    open func closeMenu(){
+        self.closeAllViews()
+    }
+    
     // MARK:- Get Rendered Image Functions
     func getRenderedImage(afterScreenUpdates: Bool = false) -> UIImage{
         let renderer = UIGraphicsImageRenderer(size: viewTargeted.bounds.size)


### PR DESCRIPTION
## Purpose
While using this pod in my app, I realized there was no way to dismiss programatically. I encountered this while wanting to dismiss the menu if the app received a notification that we want to display in-app.

## Implementation
Not much change, just added an open func that calls through to `closeAllViews()`