### PR TITLE
Got rid call to fixTargetedImageViewExtrudings()

### DIFF
--- a/ContextMenuSwift/ContextMenu.swift
+++ b/ContextMenuSwift/ContextMenu.swift
@@ -755,7 +755,6 @@ open class ContextMenu: NSObject {
         mY = tvY + MenuConstants.MenuMarginSpace
         mX = MenuConstants.HorizontalMarginSpace
         
-        self.fixTargetedImageViewExtrudings()
         
 //        else{
 //            if ((mainViewRect.width/2) - (mX + mW/2))/mainViewRect.width <= 0.5  {


### PR DESCRIPTION


https://user-images.githubusercontent.com/7041880/103595495-69baea00-4eb0-11eb-9d13-3ac27816345b.MP4

I found this function to be buggy, especially when working on a view on the far right side of the screen, and results in the target view jumping across the screen. Also given all the commented out code in this function, it looks fairly unfinished as well.